### PR TITLE
fix: enable FastReport script security (CVE-2020-27998) (#55)

### DIFF
--- a/TN_Doc/Controllers/HomeController.cs
+++ b/TN_Doc/Controllers/HomeController.cs
@@ -385,7 +385,6 @@ public class HomeController : Controller
         ViewData["Version"] = provider.Version;
         try
         {
-            FastReport.Utils.Config.EnableScriptSecurity = false;
             _fr.EnableMargins = true;
             _fr.Mode = WebReportMode.Preview;
             _fr.SinglePage = true;


### PR DESCRIPTION
## Проблема
`FastReport.Utils.Config.EnableScriptSecurity = false` глобально отключает защиту скриптов FastReport. Позволяет выполнять произвольный C# код через вредоносные .frx шаблоны (CVE-2020-27998).

## Решение
Удалена строка `EnableScriptSecurity = false`. Безопасность скриптов включена по умолчанию.

Closes #55