### PR TITLE
fix: prevent DbContext connection leak in DbSchemaCache (#58)

### DIFF
--- a/TN_Doc/Services/DbSchemaCache.cs
+++ b/TN_Doc/Services/DbSchemaCache.cs
@@ -62,7 +62,7 @@ public class DbSchemaCache : IDbSchemaCache
                 return false;
             }
 
-            var dbService = new DBtService(cfgDevice.DBConnectionStrings.Where(x => x.Use).ToList());
+            using var dbService = new DBtService(cfgDevice.DBConnectionStrings.Where(x => x.Use).ToList());
             var fields = dbService.GetTableInfo(tableName);
 
             var hasDataArm = fields.Any(f => string.Equals(f.Field, "DataARM", StringComparison.OrdinalIgnoreCase));


### PR DESCRIPTION
## Проблема
`CheckDataArmExists()` создаёт экземпляр `DBtService` (наследник DbContext) без `using`, соединение MySQL никогда не освобождается. При многих вызовах это приведёт к исчерпанию пула соединений.

## Решение
Добавлен `using` перед `var dbService = new DBtService(...)` в `DbSchemaCache.CheckDataArmExists()`.

Closes #58